### PR TITLE
Correction de test behat.

### DIFF
--- a/tests/behat/login_google.feature
+++ b/tests/behat/login_google.feature
@@ -19,7 +19,7 @@ Feature: Sign in with a Google account
     And I set the field "googleclientid" to "1234567890"
     And I set the field "googleclientsecret" to "1234567890"
     And I press "Save changes"
-    When I follow "Log out"
+    And I log out
     Then I should see "Home"
     When I follow "Log in"
     Then I should see "Sign-in with Google"


### PR DESCRIPTION
When I run behat tests (Moodle 2.8.6 version), and I got this error: 

***********************
Moodle 2.8.6 (Build: 20150511, Build StudiUM: 2015060300), mysqli, fa9a7fe865fe4e425eb765c0cb18796a6a090cce
Server OS "Linux", Browser: "firefox"
Started at 13-08-2015, 01:40
.............F---

(::) failed steps (::)

01. The "(//html/.//a[./@href][(((./@id = 'Log out' or contains(normalize-space(string(.)), 'Log out')) or contains(./@title, 'Log out') or contains(./@rel, 'Log out')) or .//img[contains(./@alt, 'Log out')])] | .//*[./@role = 'link'][((./@id = 'Log out' or contains(./@value, 'Log out')) or contains(./@title, 'Log out') or contains(normalize-space(string(.)), 'Log out'))])[1]" xpath node is not visible and it should be visible
In step `When I follow "Log out"'. # behat_general::click_link()
From scenario `Sign in with a Google account'. # /moodle/auth/googleoauth2/tests/behat/login_google.feature:8
Of feature `Sign in with a Google account'. # /moodle/auth/googleoauth2/tests/behat/login_google.feature

1 scenario (1 failed)
17 steps (13 passed, 3 skipped, 1 failed)
0m52.75s
***********************

I just modified the .feature file, I changed the step «When I follow "Log out"» for «And I log out» and after that everything runs without problems.

***********************
Moodle 2.8.6 (Build: 20150511, Build StudiUM: 2015060300), mysqli, fa9a7fe865fe4e425eb765c0cb18796a6a090cce
Server OS "Linux", Browser: "firefox"
Started at 13-08-2015, 02:08
..................

1 scenario (1 passed)
18 steps (18 passed)
2m51.883s
***********************

Thanks!