### PR TITLE
Only change font for the buttons, not all the elements

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,7 +1,5 @@
-* {
-    font-family: 'Open Sans', sans-serif;
-}
 .button-fill {
+    font-family: 'Open Sans', sans-serif;
     text-align: center;
     background: #ccc;
     display: inline-block;


### PR DESCRIPTION
The * style change the font for all the elements. Its an unwanted behavior because a plugin may not styling stuff outside of its scope. I just move the font-call to the buttons elements.