### PR TITLE
Update the version of the league/oauth2-client from 0.11 to 0.12.1

### DIFF
--- a/VENDOR CHANGES.md
+++ b/VENDOR CHANGES.md
@@ -1,12 +1,7 @@
 List here the hacks that need to be done in the 'vendor' folder.
 
 * class Depotwarehouse\OAuth2\Client\ProviderBattleNet
-=> change battle.net urls: us to eu (if you want to use the european server of course)
+=> change battle.net urls: us to eu (if you want to use the european server of course).
 
-* pixelfear/oauth2-dropox
+* pixelfear/oauth2-dropbox
 => nothing to do, just saying that I actually use a personal fork of this rep where I changed the require version of League oauth2.
-
-* class League\OAuth2\Client\Provider\LinkedIn
-=> test if $response->publicProfileUrl is not empty.
-   The problem here is that the provider class expect the r_contactinfo scope which need to be manually requested to LinkedIn.
-   'urls' => isset($response->publicProfileUrl)?$response->publicProfileUrl:'',

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
       }
     ],
     "require": {
-        "league/oauth2-client": "^0.11.0",
+        "league/oauth2-client": "^0.12.1",
         "depotwarehouse/oauth2-bnet": "^3.0",
         "pixelfear/oauth2-dropbox": "dev-bugfix"
     }


### PR DESCRIPTION
This allow to fix the hack concerning LinkedIn.
The log say its fixed in 0.12.0 (see https://github.com/thephpleague/oauth2-client/blob/master/CHANGELOG.md#user-content-0120) so I updated the league/oauth2-client.
Its still work with this version but I don't know how to reproduce it.
Also, I cannot update further than 0.12.1 (ex. to version 1.0.2) because I've got dependency errors.