### PR TITLE
Sign-On-O-Tron support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,6 @@ If you need to know more about composer, you can read [Composer Namespaces in 5 
 
 [![Throughput Graph](https://graphs.waffle.io/mouneyrac/moodle-auth_googleoauth2/throughput.svg)](https://waffle.io/mouneyrac/moodle-auth_googleoauth2/metrics)
 
-### Need some help / a fix / a new feature / some improvement / pull request to be quickly integrated
-create an issue in the [tracker](https://github.com/mouneyrac/moodle-auth_googleoauth2/issues) if an issue doesn't already exist for what you need. Once the issue created, a link to Bounty Source will be added to the issue description. From there you will be able to indicate how much you would like to pay for the issue to be answered/solved/peer-reviewed/tested/integrated.
-
 ### Credits
 * [Contributors](https://github.com/mouneyrac/auth_googleoauth2/graphs/contributors)
 * [The PHP League oauth2 client](https://github.com/thephpleague/oauth2-client)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ PHP 5.5
 7. in the plugin settings, follow the displayed instructions.
 or just install the plugin from [Moodle.org repository plugin page](https://moodle.org/plugins/view/auth_googleoauth2)
 
+If you have any issues you can follow the Git chapter of my free mini-course [how to install a Moodle plugin](http://bepaw-open-source-school.teachable.com/courses/how-to-install-a-plugin). It is using the Oauth2 plugin as example.
+
 ### Implement your own provider (for devs)
 1. add your third party provider for Oauth2 client as explain in https://github.com/thephpleague/oauth2-client
 2. create /classes/provider/newprovidername.php and newprovidername_redirect.php. Then add the lang strings in /lang/en/auth_googleoauth2.php

--- a/VENDOR CHANGES.md
+++ b/VENDOR CHANGES.md
@@ -5,3 +5,6 @@ List here the hacks that need to be done in the 'vendor' folder.
 
 * pixelfear/oauth2-dropbox
 => nothing to do, just saying that I actually use a personal fork of this rep where I changed the require version of League oauth2.
+
+* learningpool/oauth2-signonotron
+=> open src/Provider/signonotron.ini.dist, add your site's URL, and save the file as signonotron.ini

--- a/auth.php
+++ b/auth.php
@@ -407,7 +407,7 @@ class auth_plugin_googleoauth2 extends auth_plugin_base {
                 $content = str_replace(array("\n", "\r"), array("\\\n", "\\\r"), auth_googleoauth2_display_buttons(false));
                 $PAGE->requires->css('/auth/googleoauth2/style.css');
                 $PAGE->requires->js_init_code("buttonsCodeOauth2 = '$content';");
-                $PAGE->requires->js(new moodle_url($CFG->wwwroot . "/auth/googleoauth2/script.js"));
+                $PAGE->requires->js(new moodle_url($CFG->httpswwwroot . "/auth/googleoauth2/script.js"));
             }
         }
     }

--- a/classes/provider/signonotron.php
+++ b/classes/provider/signonotron.php
@@ -22,7 +22,7 @@ class provideroauth2signonotron extends Learningpool\OAuth2\Client\Provider\Sign
     public $sskstyle = 'signonotron';
     public $name = 'signonotron'; // It must be the same as the XXXXX in the class name provideroauth2XXXXX.
     public $readablename = 'Sign-On-O-Tron';
-    public $scopes = array('email');
+    public $scopes = array();
 
     /**
      * Constructor.

--- a/lang/en/auth_googleoauth2.php
+++ b/lang/en/auth_googleoauth2.php
@@ -96,7 +96,7 @@ $string['auth_microsoftclientid'] = 'Your Client ID/Secret can be generated at <
 $string['auth_microsoftclientid_key'] = 'Microsoft v2 Application ID';
 $string['auth_microsoftclientsecret'] = '';
 $string['auth_microsoftclientsecret_key'] = 'Microsoft v2 Application secret';
-$string['auth_signonotronclientid'] = 'Information on how to generate the Sign-On-O-Tron Client ID/Secret can be found <a href = "https://github.com/alphagov/signonotron2/blob/master/doc/usage.md" target="_blank">here</a>. Sign-On-O-Tron only accepts HTTPS. Sign-On-O-Tron requires some additional setup, see the readme at: googleoauth2/vendor/learningpool/oauth2-signonotron/README.md
+$string['auth_signonotronclientid'] = 'Information on how to generate the Sign-On-O-Tron Client ID/Secret can be found <a href = "https://github.com/alphagov/signonotron2/blob/master/doc/usage.md" target="_blank">here</a>. Sign-On-O-Tron only accepts HTTPS. Sign-On-O-Tron requires some additional setup, see VENDOR CHANGES.md and the readme at: googleoauth2/vendor/learningpool/oauth2-signonotron/README.md
 <br/>Site URL: {$a->siteurl}
 <br/>Site domain: {$a->sitedomain}
 <br/>Valid OAuth redirect URIs: {$a->callbackurl}';

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version  = 2015110600;
+$plugin->version  = 2016061200;
 $plugin->requires = 2014051200;   // Requires Moodle 2.7 or later.
-$plugin->release = '2.2 (Build: 2015110600)';
+$plugin->release = '2.3 (Build: 2016061200)';
 $plugin->maturity = MATURITY_STABLE;             // This version's maturity level.
 $plugin->component = 'auth_googleoauth2'; // Declare the type and name of this plugin.


### PR DESCRIPTION
* Added support for the Sign-On-O-Tron oauth2 provider. Information about it can be found [here](https://github.com/alphagov/signonotron2).

* Changed the javascript require to use httpswwwroot because the buttons weren't showing up on https login pages.